### PR TITLE
Change default method in "use" table

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -131,7 +131,7 @@ CREATE TABLE `user` (
   `is_admin` int(2) NOT NULL DEFAULT '0',
   `ref_by` int(11) NOT NULL DEFAULT '0',
   `expire_time` int(11) NOT NULL DEFAULT '0',
-  `method` varchar(64) NOT NULL DEFAULT 'aes-256-cfb',
+  `method` varchar(64) NOT NULL DEFAULT 'aes-128-ctr',
   `is_email_verify` tinyint(4) NOT NULL DEFAULT '0',
   `reg_ip` varchar(128) NOT NULL DEFAULT '127.0.0.1',
   `level` varchar(32) NOT NULL DEFAULT '1',


### PR DESCRIPTION
The default methon "AES-256-cfb" is less performance than "AES-128-ctr", so I suggest to change it to "AES-128-ctr" for bettery performance and battery drain.